### PR TITLE
Add version checker

### DIFF
--- a/.sealog/changes/1-4-0.edn
+++ b/.sealog/changes/1-4-0.edn
@@ -1,0 +1,11 @@
+{:version      {:major 1
+                :minor 4
+                :patch 0}
+ :version-type :semver3
+ :changes      {:added      ["`sealog.version` namespace with functions for working with Clojure versions."]
+                :changed    ["`sealog.core/when-let+` throws a more specific exception when the bindings vector contains an odd number of forms."]
+                :deprecated []
+                :removed    []
+                :fixed      []
+                :security   []}
+ :timestamp    "2024-10-07T16:12:46.608149864Z"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Table of Contents
 
+* [1.4.0 - 2024-10-07](#140---2024-10-07)
 * [1.3.0 - 2024-09-21](#130---2024-09-21)
 * [1.2.3 - 2024-05-03](#123---2024-05-03)
 * [1.2.2 - 2024-03-10](#122---2024-03-10)
@@ -14,6 +15,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [1.1.0 - 2022-11-14](#110---2022-11-14)
 * [1.0.1 - 2022-10-06](#101---2022-10-06)
 * [1.0.0 - 2022-10-06](#100---2022-10-06)
+
+## 1.4.0 - 2024-10-07
+
+* Added
+  * `sealog.version` namespace with functions for working with Clojure versions.
+* Changed
+  * `sealog.core/when-let+` throws a more specific exception when the bindings vector contains an odd number of forms.
 
 ## 1.3.0 - 2024-09-21
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: version/major version/minor version/patch changelog/render
 
 MAKE = make
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spoon",
-  "version": "1.2.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spoon",
-      "version": "1.2.2",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "karma": "^6.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoon",
-  "version": "1.2.2",
+  "version": "1.4.0",
   "description": "A collection of non-domain-specific utility functions",
   "main": "index.js",
   "directories": {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.wallbrew</groupId>
   <artifactId>spoon</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <name>spoon</name>
   <description>A collection of non-domain-specific utility functions.</description>
   <url>https://github.com/Wall-Brew-Co/spoon</url>
@@ -20,7 +20,7 @@
     <url>https://github.com/Wall-Brew-Co/spoon</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/spoon.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/spoon.git</developerConnection>
-    <tag>8189dfa03a11d021d85aca0b0870ae7a41a3c8eb</tag>
+    <tag>f91e4f6a5fcbac97720c769601fdd5d22c59873c</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/spoon "1.3.0"
+(defproject com.wallbrew/spoon "1.4.0"
   :description "A collection of non-domain-specific utility functions."
   :url "https://github.com/Wall-Brew-Co/spoon"
   :license {:name         "MIT"

--- a/src/com/wallbrew/spoon/compatibility.cljc
+++ b/src/com/wallbrew/spoon/compatibility.cljc
@@ -12,7 +12,7 @@
      however, many libraries included this function either in their API or their implementation.
    This leads consumers to continually receive warnings about shadowed functionality;
      however, libraries cannot leverage the version in `clojure.core` without breaking compatibility for consumers using older versions of clojure.
-   
+
    Example:
    ```clj
    (update-vals* {:a 1 :b 2} inc) ; => {:a 2 :b 3}
@@ -32,7 +32,7 @@
      however, many libraries included this function either in their API or their implementation.
    This leads consumers to continually receive warnings about shadowed functionality;
      however, libraries cannot leverage the version in `clojure.core` without breaking compatibility for consumers using older versions of clojure.
-   
+
    Example:
    ```clj
    (update-keys* {:a 2 :b 3} name) ; => {\"a\" 2 \"b\" 3}
@@ -44,3 +44,5 @@
               "update-vals"]}
   [m f & args]
   (reduce-kv (fn [m' k v] (assoc m' (apply f k args) v)) {} m))
+
+

--- a/src/com/wallbrew/spoon/core.cljc
+++ b/src/com/wallbrew/spoon/core.cljc
@@ -10,21 +10,24 @@
    If all bindings evaluate truthy, the body will be evaluated in an implicit `do` in which all bindings are bound to the value of their test.
    If any binding evaluates falsey, the body will not be evaluated and nil will be returned.
    If multiple forms are provided, the last form will be returned.
-   
+   If the bindings vector contains an invalid number of forms, an assertion error will be thrown.
+
    Example:
    ```clj
-   (when-let+ 
+   (when-let+
      [a 1 b 2]
      (+ a b)) ; => 3
 
-   (when-let+ 
+   (when-let+
      [a nil b 2]
      (+ a b)) ; => nil
    ```"
   {:added    "1.0"
+   :changed  "1.4"
    :see-also ["clojure.core/when-let"]}
   [bindings & body]
-  (assert (even? (count bindings)))
+  (assert (even? (count bindings))
+          "`when-let+` requires an even number of forms in the bindings vector.")
   (if (seq bindings)
     `(when-let [~(first bindings) ~(second bindings)]
        (when-let+ ~(vec (drop 2 bindings)) ~@body))
@@ -52,7 +55,7 @@
 
 (defn filter-by-values
   "Return `m` with only the key:value pairs whose values cause `pred` to evaluate truthily.
-   
+
    Example:
    ```clj
    (filter-by-values nil? {}) ; => {}
@@ -70,7 +73,7 @@
 
 (defn filter-by-keys
   "Return `m` with only the key:value pairs whose keys cause `pred` to evaluate truthily.
-   
+
    Example:
    ```clj
    (filter-by-keys nil? {}) ; => {}
@@ -88,7 +91,7 @@
 
 (defn remove-by-values
   "Return `m` with only the key:value pairs whose values cause `pred` to evaluate falsily.
-   
+
    Example:
    ```clj
    (remove-by-values nil? {}) ; => {}
@@ -106,7 +109,7 @@
 
 (defn remove-by-keys
   "Return `m` with only the key:value pairs whose keys cause `pred` to evaluate falsily.
-   
+
    Example:
    ```clj
    (remove-by-keys nil? {}) ; => {}

--- a/src/com/wallbrew/spoon/string.cljc
+++ b/src/com/wallbrew/spoon/string.cljc
@@ -28,7 +28,7 @@
   :uppercase?)
 
 
-(defn- prepare-for-compare
+(defn prepare-for-compare
   "Takes a string `s`, trims it, and coerces it to lower case.
 
    An option map may be passed as an optional second argument.

--- a/src/com/wallbrew/spoon/version.clj
+++ b/src/com/wallbrew/spoon/version.clj
@@ -1,0 +1,80 @@
+(ns com.wallbrew.spoon.version
+  "Tools to inspect and compare Clojure versions."
+  {:added "1.4"})
+
+
+(defn current-clojure-version
+  "Returns the current version of Clojure as a map.
+   This is a shim to resolve the dynamic var `*clojure-version*` and sidestep a clj-kondo warning."
+  {:added "1.4"
+   :no-doc true}
+  []
+  #_{:clj-kondo/ignore [:unresolved-symbol]}
+  *clojure-version*)
+
+
+(defn ->printable-clojure-version
+  "Returns clojure version as a printable string.
+
+   For example:
+   ```clj
+   (->printable-clojure-version {:major 1 :minor 12 :incremental 0 :qualifier nil}) ; => \"1.12.0\"
+   (->printable-clojure-version {:major 1 :minor 12 :incremental 0 :qualifier \"alpha\"}) ; => \"1.12.0-alpha\"
+   (->printable-clojure-version {:major 1 :minor 12 :incremental 0 :qualifier \"alpha\" :interim 1}) ; => \"1.12.0-alpha-SNAPSHOT\"
+   ```"
+  {:added "1.4"
+   :see-also ["clojure.core/clojure-version"]}
+  [{:keys [major minor incremental qualifier interim] :as _version}]
+  (str major
+       "."
+       minor
+       (when-let [i incremental]
+         (str "." i))
+       (when-let [q qualifier]
+         (when (pos? (count q))
+           (str "-" q)))
+       (when interim
+         "-SNAPSHOT")))
+
+
+(defn assert-minimum-clojure-version!
+  "Assert that the current version of Clojure is at least `min-version`.
+   If the versions are incompatible, it throws an assertion error with a message indicating the incompatibility.
+   If the versions are, or may be compatible, it returns a keyword indicating the compatibility level:
+
+     - `:safe` - The Semantic Versions of the current and minimum versions are compatible.
+     - `:warn` - The Semantic Versions of the current and minimum versions may be incompatible.
+                 For example, a major version bump in the language version may introduce breaking changes in the API.
+                 However, the current version may still be compatible with the minimum version.
+
+   `min-version` should be a map with the same structure as the dynamic var `clojure-version`.
+   For example, the dependency `[org.clojure/clojure \"1.12.0\"]` would translate to:
+   ```clj
+   *clojure-version*
+    ; => {:major 1, :minor 12, :incremental 0, :qualifier nil}
+   ```
+
+   This function is useful for libraries that require a minimum version of Clojure to function properly."
+  {:added    "1.4"
+   :see-also ["clojure.core/clojure-version"
+              "clojure.core/*clojure-version*"]}
+  [{:keys [major minor incremental qualifier] :as min-version}]
+  (let [current-version     (current-clojure-version)
+        current-major       (:major current-version)
+        current-minor       (:minor current-version)
+        current-incremental (:incremental current-version)
+        current-qualifier   (:qualifier current-version)
+        comparison (cond
+                     (< major current-major) :warn
+                     (> major current-major) :error
+                     (> minor current-minor) :error
+                     (> incremental current-incremental) :error
+                     (and qualifier (nil? current-qualifier)) :error
+                     (and qualifier (not= qualifier current-qualifier)) :error
+                     :else :safe)]
+    (assert (not= :error comparison)
+            (str "The current Clojure version "
+                 (->printable-clojure-version current-version)
+                 " is not compatible with the minimum required version "
+                 (->printable-clojure-version min-version)))
+    comparison))

--- a/test/com/wallbrew/spoon/compatibility_test.cljc
+++ b/test/com/wallbrew/spoon/compatibility_test.cljc
@@ -4,14 +4,24 @@
 
 
 (deftest update-vals-test
+  ;; N.B. These tests do not compare themselves to the clojure.core/update-vals function
+  ;;      We do this so we are able to run the test suite against older versions of Clojure
   (testing "Functional correctness"
-    (is (= {:a 2 :b 3} (sut/update-vals {:a 1 :b 2} inc)))
-    (is (= {} (sut/update-vals {} dec)))
-    (is (= {:b 3 :c 4} (sut/update-vals {:b 1 :c 2} + 2)))))
+    (is (= {:a 2 :b 3}
+           (sut/update-vals {:a 1 :b 2} inc)))
+    (is (= {}
+           (sut/update-vals {} dec)))
+    (is (= {:b 3 :c 4}
+           (sut/update-vals {:b 1 :c 2} + 2)))))
 
 
 (deftest update-keys-test
+  ;; N.B. These tests do not compare themselves to the clojure.core/update-keys function
+  ;;      We do this so we are able to run the test suite against older versions of Clojure
   (testing "Functional correctness"
-    (is (= {"a" 2 "b" 3} (sut/update-keys {:a 2 :b 3} name)))
-    (is (= {} (sut/update-keys {} dec)))
-    (is (= {":b-key" 3 ":c-key" 4} (sut/update-keys {:b 3 :c 4} str "-key")))))
+    (is (= {"a" 2 "b" 3}
+           (sut/update-keys {:a 2 :b 3} name)))
+    (is (= {}
+           (sut/update-keys {} dec)))
+    (is (= {":b-key" 3 ":c-key" 4}
+           (sut/update-keys {:b 3 :c 4} str "-key")))))

--- a/test/com/wallbrew/spoon/string_test.cljc
+++ b/test/com/wallbrew/spoon/string_test.cljc
@@ -191,30 +191,35 @@
     (is (false? (sut/not-blank? "
                                  ")))))
 
+
 #_{:clj-kondo/ignore [:unresolved-symbol]}
 
 
 (check.test/defspec
   prepare-for-compare-type-no-map 100
   (prop/for-all
-   [s1 generate/string]
-   (string? (sut/prepare-for-compare s1))))
+    [s1 generate/string]
+    (string? (sut/prepare-for-compare s1))))
+
 
 #_{:clj-kondo/ignore [:unresolved-symbol]}
+
 
 (check.test/defspec
   prepare-for-compare-type-false-map 100
   (prop/for-all
-   [s1 generate/string]
-   (string? (sut/prepare-for-compare s1 {sut/cast-to-uppercase? false}))))
+    [s1 generate/string]
+    (string? (sut/prepare-for-compare s1 {sut/cast-to-uppercase? false}))))
+
 
 #_{:clj-kondo/ignore [:unresolved-symbol]}
+
 
 (check.test/defspec
   prepare-for-compare-type-true-map 100
   (prop/for-all
-   [s1 generate/string]
-   (string? (sut/prepare-for-compare s1 {sut/cast-to-uppercase? true}))))
+    [s1 generate/string]
+    (string? (sut/prepare-for-compare s1 {sut/cast-to-uppercase? true}))))
 
 
 (deftest prepare-for-compare-test
@@ -234,10 +239,10 @@
            (sut/prepare-for-compare "aaa   " {sut/cast-to-uppercase? false})
            (sut/prepare-for-compare "   aaa" {sut/cast-to-uppercase? false})))
     (is (= "AAA"
-            (sut/prepare-for-compare "   AAA   " {sut/cast-to-uppercase? true})
-            (sut/prepare-for-compare "AAA" {sut/cast-to-uppercase? true})
-            (sut/prepare-for-compare "AAA   " {sut/cast-to-uppercase? true})
-            (sut/prepare-for-compare "   AAA" {sut/cast-to-uppercase? true}))))
+           (sut/prepare-for-compare "   AAA   " {sut/cast-to-uppercase? true})
+           (sut/prepare-for-compare "AAA" {sut/cast-to-uppercase? true})
+           (sut/prepare-for-compare "AAA   " {sut/cast-to-uppercase? true})
+           (sut/prepare-for-compare "   AAA" {sut/cast-to-uppercase? true}))))
   (testing "prepare-for-compare coerces strings to lower case by default"
     (is (= "aaa"
            (sut/prepare-for-compare "AaA")

--- a/test/com/wallbrew/spoon/string_test.cljc
+++ b/test/com/wallbrew/spoon/string_test.cljc
@@ -188,5 +188,60 @@
     (is (false? (sut/not-blank? "")))
     (is (false? (sut/not-blank? " ")))
     (is (false? (sut/not-blank? "     ")))
-    (is (false? (sut/not-blank? "   
+    (is (false? (sut/not-blank? "
                                  ")))))
+
+#_{:clj-kondo/ignore [:unresolved-symbol]}
+
+
+(check.test/defspec
+  prepare-for-compare-type-no-map 100
+  (prop/for-all
+   [s1 generate/string]
+   (string? (sut/prepare-for-compare s1))))
+
+#_{:clj-kondo/ignore [:unresolved-symbol]}
+
+(check.test/defspec
+  prepare-for-compare-type-false-map 100
+  (prop/for-all
+   [s1 generate/string]
+   (string? (sut/prepare-for-compare s1 {sut/cast-to-uppercase? false}))))
+
+#_{:clj-kondo/ignore [:unresolved-symbol]}
+
+(check.test/defspec
+  prepare-for-compare-type-true-map 100
+  (prop/for-all
+   [s1 generate/string]
+   (string? (sut/prepare-for-compare s1 {sut/cast-to-uppercase? true}))))
+
+
+(deftest prepare-for-compare-test
+  (testing "not-blank? is a function from a string to a string"
+    (is (string? (sut/prepare-for-compare (gen/generate (spec/gen ::string)))))
+    (is (string? (sut/prepare-for-compare (gen/generate (spec/gen ::string)) {sut/cast-to-uppercase? false})))
+    (is (string? (sut/prepare-for-compare (gen/generate (spec/gen ::string)) {sut/cast-to-uppercase? true}))))
+  (testing "Prepare-for-compare returns a string with no leading or trailing whitespace"
+    (is (= "aaa"
+           (sut/prepare-for-compare "   aaa   ")
+           (sut/prepare-for-compare "aaa")
+           (sut/prepare-for-compare "aaa   ")
+           (sut/prepare-for-compare "   aaa")))
+    (is (= "aaa"
+           (sut/prepare-for-compare "   aaa   " {sut/cast-to-uppercase? false})
+           (sut/prepare-for-compare "aaa" {sut/cast-to-uppercase? false})
+           (sut/prepare-for-compare "aaa   " {sut/cast-to-uppercase? false})
+           (sut/prepare-for-compare "   aaa" {sut/cast-to-uppercase? false})))
+    (is (= "AAA"
+            (sut/prepare-for-compare "   AAA   " {sut/cast-to-uppercase? true})
+            (sut/prepare-for-compare "AAA" {sut/cast-to-uppercase? true})
+            (sut/prepare-for-compare "AAA   " {sut/cast-to-uppercase? true})
+            (sut/prepare-for-compare "   AAA" {sut/cast-to-uppercase? true}))))
+  (testing "prepare-for-compare coerces strings to lower case by default"
+    (is (= "aaa"
+           (sut/prepare-for-compare "AaA")
+           (sut/prepare-for-compare "AaA" {sut/cast-to-uppercase? false}))))
+  (testing "prepare-for-compare can coerce strings to upper case"
+    (is (= "AAA"
+           (sut/prepare-for-compare "AaA" {sut/cast-to-uppercase? true})))))

--- a/test/com/wallbrew/spoon/version_test.clj
+++ b/test/com/wallbrew/spoon/version_test.clj
@@ -1,0 +1,67 @@
+(ns com.wallbrew.spoon.version-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [com.wallbrew.spoon.version :as sut]))
+
+
+(deftest ->printable-clojure-version-test
+  (testing "Functional correctness"
+    (is (string? (sut/->printable-clojure-version (sut/current-clojure-version))))
+    (is (= #_{:clj-kondo/ignore [:unresolved-symbol]}
+           (clojure-version)
+           (sut/->printable-clojure-version (sut/current-clojure-version))))
+    (is (= "1.12.0"
+           (sut/->printable-clojure-version {:major       1
+                                             :minor       12
+                                             :incremental 0})))
+    (is (= "1.12.0-alpha"
+           (sut/->printable-clojure-version {:major       1
+                                             :minor       12
+                                             :incremental 0
+                                             :qualifier   "alpha"})))
+    (is (= "1.12.0-alpha-SNAPSHOT"
+           (sut/->printable-clojure-version {:major       1
+                                             :minor       12
+                                             :incremental 0
+                                             :qualifier   "alpha"
+                                             :interim     true})))
+    (is (= "1.12.0-SNAPSHOT"
+           (sut/->printable-clojure-version {:major       1
+                                             :minor       12
+                                             :incremental 0
+                                             :qualifier   nil
+                                             :interim     true})))))
+
+
+(deftest jvm-assert-minimum-clojure-version!-test
+  (let [sample-version {:major       1
+                        :minor       2
+                        :incremental 3
+                        :qualifier   nil}]
+    (testing "Versions are identical"
+      (with-redefs [sut/current-clojure-version (constantly sample-version)]
+        (is (= :safe
+               (sut/assert-minimum-clojure-version! sample-version)))))
+    (testing "The current major version is greater than the minimum major version"
+      (with-redefs [sut/current-clojure-version (constantly (update sample-version :major inc))]
+        (is (= :warn
+               (sut/assert-minimum-clojure-version! sample-version)))))
+    (testing "Minimum major version is greater than current major version"
+      (with-redefs [sut/current-clojure-version (constantly sample-version)]
+        (is (thrown? AssertionError
+              (sut/assert-minimum-clojure-version! (update sample-version :major inc))))))
+    (testing "Minimum minor version is greater than current minor version"
+      (with-redefs [sut/current-clojure-version (constantly sample-version)]
+        (is (thrown? AssertionError
+              (sut/assert-minimum-clojure-version! (update sample-version :minor inc))))))
+    (testing "Minimum incremental version is greater than current incremental version"
+      (with-redefs [sut/current-clojure-version (constantly sample-version)]
+        (is (thrown? AssertionError
+              (sut/assert-minimum-clojure-version! (update sample-version :incremental inc))))))
+    (testing "Minimum version includes a qualifier, but current version does not"
+      (with-redefs [sut/current-clojure-version (constantly sample-version)]
+        (is (thrown? AssertionError
+              (sut/assert-minimum-clojure-version! (assoc sample-version :qualifier "alpha"))))))
+    (testing "Minimum version and current version include a qualifier, but they are not equal"
+      (with-redefs [sut/current-clojure-version (constantly (assoc sample-version :qualifier "beta"))]
+        (is (thrown? AssertionError
+              (sut/assert-minimum-clojure-version! (assoc sample-version :qualifier "alpha"))))))))


### PR DESCRIPTION
# Proposed Changes

- Additions: `sealog.version` namespace with functions for working with Clojure versions.
- Updates: `sealog.core/when-let+` throws a more specific exception when the bindings vector contains an odd number of forms.
- Deletions:

## Pre-merge Checklist

- [x] Read and agree to the Contribution Guidelines and Code of Conduct
- [x] Write new tests for the changed functionality
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
